### PR TITLE
Fix Monolith spawning for YUNG's Better Nether Fortresses.

### DIFF
--- a/src/generated/resources/data/celestisynth/tags/worldgen/structure/nether_monolith_spawn.json
+++ b/src/generated/resources/data/celestisynth/tags/worldgen/structure/nether_monolith_spawn.json
@@ -1,9 +1,6 @@
 {
   "values": [
     "minecraft:fortress",
-    {
-      "id": "#betterfortresses:fortress",
-      "required": false
-    }
+    "betterfortresses:fortress"
   ]
 }


### PR DESCRIPTION
This fixes the spawning for YUNG's Better Fortresses for some reason, oh well.